### PR TITLE
Added marketer list sync. Iterate over marketers

### DIFF
--- a/tap_outbrain/schemas.py
+++ b/tap_outbrain/schemas.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+# pylint: disable=invalid-name
 link = {
     'type': 'object',
     'properties': {
@@ -81,7 +81,6 @@ link = {
         }
     }
 }
-
 
 campaign = {
     'type': 'object',
@@ -214,7 +213,6 @@ campaign = {
     }
 }
 
-
 campaign_performance = {
     'type': 'object',
     'properties': {
@@ -336,4 +334,36 @@ link_performance = {
                             'Calculated as: (spend / conversions)')
         }
     }
+}
+
+marketer = {
+    'type': 'object',
+    'properties': {
+        'id': {
+            'type': 'number'
+        },
+        'name': {
+            'type': 'string'
+        },
+        'enabled': {
+            'type': 'boolean'
+        },
+        'currency': {
+            'type': 'string'
+        },
+        'creationTime': {
+            'type': 'string',
+            'format': 'date-time',
+        },
+        'lastModified': {
+            'type': 'string',
+            'format': 'date-time',
+        },
+        'blockedSites': {
+            'type': 'string'
+        },
+        'useFirstPartyCookie': {
+            'type': 'boolean'
+        },
+    },
 }


### PR DESCRIPTION
# Description of change
Added sync_marketers to retireve [all marketers](https://amplifyv01.docs.apiary.io/#reference/marketers/list-marketers) that the authenticated account is allowed to view. The marketers are synced and then the tap then iterates over these accounts to sync all campaigns from all marketers.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
