### PR TITLE
SAC-31234: Exlcude un-auth streams from catalog while discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.2.0
-  * Exclude un-authorized streams from the catalog during discovery. [#34](https://github.com/singer-io/tap-outbrain/pull/34)
+  * Exclude unauthorized streams from the catalog during discovery. [#34](https://github.com/singer-io/tap-outbrain/pull/34)
 
 ## 1.1.0
   * Upgrade Python to 3.12 in CircleCI [#30](https://github.com/singer-io/tap-outbrain/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.2.0
-  * Exclude un-authorized streams from the catalog during discovery. [#TBD](https://github.com/singer-io/tap-outbrain/pull/TBD)
+  * Exclude un-authorized streams from the catalog during discovery. [#34](https://github.com/singer-io/tap-outbrain/pull/34)
 
 ## 1.1.0
   * Upgrade Python to 3.12 in CircleCI [#30](https://github.com/singer-io/tap-outbrain/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+  * Exclude un-authorized streams from the catalog during discovery. [#TBD](https://github.com/singer-io/tap-outbrain/pull/TBD)
+
 ## 1.1.0
   * Upgrade Python to 3.12 in CircleCI [#30](https://github.com/singer-io/tap-outbrain/pull/30)
   * Upgrade `singer-python`, `requests` and `python-dateutil` to latest version

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-outbrain",
-      version="1.1.0",
+      version="1.2.0",
       description="Singer.io tap for extracting data from the Outbrain API",
       author="Fishtown Analytics",
       url="http://singer.io",

--- a/tap_outbrain/__init__.py
+++ b/tap_outbrain/__init__.py
@@ -294,11 +294,13 @@ def sync_campaigns(state, access_token, account_id, selected_streams):
 
     LOGGER.info('Done!')
 
-def do_discover():
+
+def do_discover(client):
     LOGGER.info("Starting discovery")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
+
 
 def do_sync(catalog: singer.Catalog, config: Dict, state):
     #pylint: disable=global-statement
@@ -355,7 +357,16 @@ def main_impl():
             'start_date'])
 
     if args.discover:
-        do_discover()
+        config = args.config
+        access_token = config.get('access_token') or generate_token(
+            config.get('username'), config.get('password')
+        )
+        if access_token is None:
+            LOGGER.fatal("Failed to generate a new access token for discover mode.")
+            raise RuntimeError
+
+        client = OutbrainClient(config={**config, 'access_token': access_token})
+        do_discover(client)
     elif args.catalog:
         state = args.state or DEFAULT_STATE
         do_sync(args.catalog, args.config, state)

--- a/tap_outbrain/client.py
+++ b/tap_outbrain/client.py
@@ -9,15 +9,22 @@ RETRY_RATE_LIMIT_MS = 360000
 LOGGER = singer.get_logger()
 SESSION = requests.Session()
 
+OUTBRAIN_API_BASE = 'https://api.outbrain.com/amplify/v0.1'
+
 
 class Server429Error(Exception):
     pass
 
 
+class OutbrainForbiddenError(Exception):
+    pass
+
+
 class OutbrainClient:
 
-    def __init__(self):
+    def __init__(self, config=None):
         self._retry_after = RETRY_RATE_LIMIT_MS / 1000.0  # Conversion to seconds
+        self.config = config or {}
 
     def _rate_limit_backoff(self):
         """
@@ -71,6 +78,10 @@ class OutbrainClient:
                     self._retry_after = RETRY_RATE_LIMIT_MS
                 self._retry_after /= 1000.0  # For miliseconds conversion to seconds
                 raise Server429Error("Rate limit exceeded")
+            elif resp.status_code == 403:
+                raise OutbrainForbiddenError(
+                    f"HTTP-error-code: 403, Error: {resp.content!r}"
+                )
             elif resp.status_code >= 400:
                 LOGGER.error(
                     f"{method} {req.url} [{resp.status_code} – {resp.content!r}]"

--- a/tap_outbrain/discover.py
+++ b/tap_outbrain/discover.py
@@ -63,7 +63,7 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
             field_metadata.pop(name, None)
 
 
-def discover(client=None) -> Catalog:
+def discover(client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
 
@@ -73,8 +73,7 @@ def discover(client=None) -> Catalog:
     """
     schemas, field_metadata = get_schemas()
 
-    if client is not None:  # Checking for client as integration tests are written without client in discovery
-        _apply_access_checks(client, schemas, field_metadata)
+    _apply_access_checks(client, schemas, field_metadata)
 
     catalog = Catalog([])
     for stream_name, schema_dict in schemas.items():

--- a/tap_outbrain/discover.py
+++ b/tap_outbrain/discover.py
@@ -63,7 +63,7 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
             field_metadata.pop(name, None)
 
 
-def discover(client) -> Catalog:
+def discover(client=None) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
 
@@ -73,7 +73,8 @@ def discover(client) -> Catalog:
     """
     schemas, field_metadata = get_schemas()
 
-    _apply_access_checks(client, schemas, field_metadata)
+    if client:  # Checking for client as integration tests are written without client in discovery
+        _apply_access_checks(client, schemas, field_metadata)
 
     catalog = Catalog([])
     for stream_name, schema_dict in schemas.items():

--- a/tap_outbrain/discover.py
+++ b/tap_outbrain/discover.py
@@ -2,15 +2,79 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 
+from tap_outbrain.client import OutbrainForbiddenError
 from tap_outbrain.schema import get_schemas
+from tap_outbrain.streams import STREAMS
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
-    """Run the discovery mode, prepare the catalog file and return the
-    catalog."""
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from *schemas* and *field_metadata* in place.
+
+    Note: ``check_access()`` always returns ``True`` for child streams, so
+    this loop effectively identifies only inaccessible parent streams by
+    design.  Child stream removal is handled separately by
+    ``_prune_inaccessible_children()``.
+
+    Raises ``OutbrainForbiddenError`` if no parent streams are accessible.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_cls in STREAMS.items()
+        if stream_name in schemas
+        and not stream_cls(client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if not schemas:
+        raise OutbrainForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have"
+            " 'read' access to any supported streams. Please re-check configuration."
+        )
+    elif inaccessible_streams:
+        LOGGER.warning(
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates *schemas* and *field_metadata* in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent"
+                " stream '%s' is not accessible.",
+                name,
+                stream_cls.parent,
+            )
+            schemas.pop(name, None)
+            field_metadata.pop(name, None)
+
+
+def discover(client) -> Catalog:
+    """
+    Run the discovery mode, prepare the catalog file and return the catalog.
+
+    When *client* is provided, access to each stream is verified using the
+    supplied ``OutbrainClient`` and streams the credentials cannot read are
+    excluded from the returned catalog.
+    """
     schemas, field_metadata = get_schemas()
+
+    _apply_access_checks(client, schemas, field_metadata)
+
     catalog = Catalog([])
     for stream_name, schema_dict in schemas.items():
         try:

--- a/tap_outbrain/discover.py
+++ b/tap_outbrain/discover.py
@@ -73,7 +73,7 @@ def discover(client=None) -> Catalog:
     """
     schemas, field_metadata = get_schemas()
 
-    if client:  # Checking for client as integration tests are written without client in discovery
+    if client is not None:  # Checking for client as integration tests are written without client in discovery
         _apply_access_checks(client, schemas, field_metadata)
 
     catalog = Catalog([])

--- a/tap_outbrain/streams.py
+++ b/tap_outbrain/streams.py
@@ -9,11 +9,11 @@ class BaseStream:
     """
     Abstract base class for all tap-outbrain streams.
 
-    Subclasses set class-level attributes describing the stream and may
-    override ``check_access()`` to probe the appropriate API endpoint.
-    Child streams (those with ``parent`` set) always return ``True`` from
-    the default ``check_access()`` implementation; their accessibility is
-    governed by their parent stream's check.
+    Subclasses set class-level attributes describing the stream and must
+    implement ``get_probe_url()`` to provide their API endpoint.  Child
+    streams (those with ``parent`` set) always return ``True`` from
+    ``check_access()``; their accessibility is governed by the parent
+    stream's check.
     """
 
     name = None
@@ -28,9 +28,13 @@ class BaseStream:
     def get_probe_url(self):
         """
         Return the URL used by check_access() to probe API read access.
-        Parent stream subclasses must override this to return their endpoint.
+        Must be implemented by every concrete parent stream subclass.
+        Child streams never reach this method (check_access returns True
+        early), so they do not need to override it.
         """
-        return None
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement get_probe_url()"
+        )
 
     def check_access(self) -> bool:
         """

--- a/tap_outbrain/streams.py
+++ b/tap_outbrain/streams.py
@@ -25,32 +25,34 @@ class BaseStream:
     def __init__(self, client=None):
         self.client = client
 
+    def get_probe_url(self):
+        """
+        Return the URL used by check_access() to probe API read access.
+        Parent stream subclasses must override this to return their endpoint.
+        """
+        return None
+
     def check_access(self) -> bool:
         """
         Verify that the API credentials have read access to this stream.
-        Returns True if accessible, False if a 403 Forbidden error is raised.
-        Child streams always return True (access is governed by the parent check).
-        """
-        return True
 
+        Child streams (those with ``parent`` set) always return True — their
+        accessibility is governed by the parent stream's check, so no API
+        probe is needed.
 
-class Campaign(BaseStream):
-    name = "campaign"
-    key_properties = ["id"]
-    replication_keys = None
-    replication_method = "FULL_TABLE"
+        Parent streams make a lightweight GET request to ``get_probe_url()``
+        and return False when the API responds with HTTP 403 Forbidden.
+        """
+        if self.parent:
+            return True
 
-    def check_access(self) -> bool:
-        """
-        Probe the campaigns endpoint to verify read access.
-        Returns False when the API responds with HTTP 403 Forbidden.
-        """
-        account_id = self.client.config.get("account_id")
+        url = self.get_probe_url()
         access_token = self.client.config.get("access_token")
         headers = {"OB-TOKEN-V1": access_token}
-        url = f"{OUTBRAIN_API_BASE}/marketers/{account_id}/campaigns"
         try:
-            self.client.make_request("GET", url, headers=headers, params={"limit": 1})
+            self.client.make_request(
+                "GET", url, headers=headers, params={"limit": 1}
+            )
             return True
         except OutbrainForbiddenError as exc:
             LOGGER.warning(
@@ -61,6 +63,18 @@ class Campaign(BaseStream):
             return False
 
 
+class Campaign(BaseStream):
+    name = "campaign"
+    key_properties = ["id"]
+    replication_keys = None
+    replication_method = "FULL_TABLE"
+
+    def get_probe_url(self):
+        """Return the campaigns endpoint for this marketer account."""
+        account_id = self.client.config.get("account_id")
+        return f"{OUTBRAIN_API_BASE}/marketers/{account_id}/campaigns"
+
+
 class CampaignPerformance(BaseStream):
     name = "campaign_performance"
     key_properties = ["campaignId", "fromDate"]
@@ -68,7 +82,8 @@ class CampaignPerformance(BaseStream):
     replication_keys = "fromDate"
     replication_method = "INCREMENTAL"
     parent = "campaign"
-    # check_access() inherited from BaseStream always returns True for child streams
+    # check_access() in BaseStream returns True for child streams.
+    # No override needed here.
 
 
 STREAMS = {

--- a/tap_outbrain/streams.py
+++ b/tap_outbrain/streams.py
@@ -1,17 +1,74 @@
-class Campaign:
+import singer
+
+from tap_outbrain.client import OUTBRAIN_API_BASE, OutbrainForbiddenError
+
+LOGGER = singer.get_logger()
+
+
+class BaseStream:
+    """
+    Abstract base class for all tap-outbrain streams.
+
+    Subclasses set class-level attributes describing the stream and may
+    override ``check_access()`` to probe the appropriate API endpoint.
+    Child streams (those with ``parent`` set) always return ``True`` from
+    the default ``check_access()`` implementation; their accessibility is
+    governed by their parent stream's check.
+    """
+
+    name = None
+    key_properties = []
+    replication_keys = None
+    replication_method = None
+    parent = None
+
+    def __init__(self, client=None):
+        self.client = client
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        """
+        return True
+
+
+class Campaign(BaseStream):
     name = "campaign"
     key_properties = ["id"]
     replication_keys = None
     replication_method = "FULL_TABLE"
 
+    def check_access(self) -> bool:
+        """
+        Probe the campaigns endpoint to verify read access.
+        Returns False when the API responds with HTTP 403 Forbidden.
+        """
+        account_id = self.client.config.get("account_id")
+        access_token = self.client.config.get("access_token")
+        headers = {"OB-TOKEN-V1": access_token}
+        url = f"{OUTBRAIN_API_BASE}/marketers/{account_id}/campaigns"
+        try:
+            self.client.make_request("GET", url, headers=headers, params={"limit": 1})
+            return True
+        except OutbrainForbiddenError as exc:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' - %s",
+                self.__class__.__name__,
+                exc,
+            )
+            return False
 
-class CampaignPerformance:
+
+class CampaignPerformance(BaseStream):
     name = "campaign_performance"
     key_properties = ["campaignId", "fromDate"]
     bookmark_properties = ["fromDate"]
     replication_keys = "fromDate"
     replication_method = "INCREMENTAL"
     parent = "campaign"
+    # check_access() inherited from BaseStream always returns True for child streams
 
 
 STREAMS = {

--- a/tests/base.py
+++ b/tests/base.py
@@ -98,13 +98,19 @@ class OutbrainBaseTest(unittest.TestCase):
         }
 
     @staticmethod
+    def _discover_catalog():
+        """Return a discovery catalog using a mock client and no access probes."""
+        with patch("tap_outbrain.discover._apply_access_checks", return_value=None):
+            return discover(client=MagicMock())
+
+    @staticmethod
     def _make_selected_catalog():
         """Return a discover() catalog with all streams marked as selected.
 
         Singer's ``catalog.get_selected_streams()`` only yields streams whose
         root metadata entry (breadcrumb == ()) contains ``selected: True``.
         """
-        catalog = discover()
+        catalog = OutbrainBaseTest._discover_catalog()
         for entry in catalog.streams:
             for m in entry.metadata:
                 if not m.get("breadcrumb"):

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -6,8 +6,6 @@ from singer import metadata
 
 from .base import OutbrainBaseTest
 
-from tap_outbrain.discover import discover
-
 
 class OutbrainAutomaticFieldsTest(OutbrainBaseTest):
     """Primary-key and replication-key fields must always be replicated."""
@@ -18,7 +16,7 @@ class OutbrainAutomaticFieldsTest(OutbrainBaseTest):
     def _get_automatic_fields(self, stream_name: str) -> set:
         """Return the set of field names that have 'automatic' inclusion for a stream."""
         # Use raw catalog (not selected) for metadata inspection
-        catalog = discover()
+        catalog = self._discover_catalog()
         stream = next(s for s in catalog.streams if s.tap_stream_id == stream_name)
         mdata_map = metadata.to_map(stream.metadata)
         pk = set(metadata.get(mdata_map, (), "table-key-properties") or [])
@@ -40,7 +38,7 @@ class OutbrainAutomaticFieldsTest(OutbrainBaseTest):
 
     def test_campaign_key_has_automatic_inclusion_metadata(self):
         """'id' in campaign must carry inclusion=automatic in Singer metadata."""
-        catalog = discover()
+        catalog = self._discover_catalog()
         campaign = next(s for s in catalog.streams if s.tap_stream_id == "campaign")
         mdata_map = metadata.to_map(campaign.metadata)
         self.assertEqual(
@@ -50,7 +48,7 @@ class OutbrainAutomaticFieldsTest(OutbrainBaseTest):
 
     def test_campaign_performance_keys_have_automatic_inclusion_metadata(self):
         """campaignId and fromDate in campaign_performance must be 'automatic'."""
-        catalog = discover()
+        catalog = self._discover_catalog()
         cp = next(s for s in catalog.streams if s.tap_stream_id == "campaign_performance")
         mdata_map = metadata.to_map(cp.metadata)
         for field in ("campaignId", "fromDate"):
@@ -63,7 +61,7 @@ class OutbrainAutomaticFieldsTest(OutbrainBaseTest):
 
     def test_non_key_campaign_fields_have_available_inclusion(self):
         """Non-key campaign fields (name, budget, cpc, …) must be 'available'."""
-        catalog = discover()
+        catalog = self._discover_catalog()
         campaign = next(s for s in catalog.streams if s.tap_stream_id == "campaign")
         mdata_map = metadata.to_map(campaign.metadata)
         for field in ("name", "campaignOnAir", "enabled", "cpc"):
@@ -75,7 +73,7 @@ class OutbrainAutomaticFieldsTest(OutbrainBaseTest):
 
     def test_non_key_performance_fields_have_available_inclusion(self):
         """Non-key performance fields (impressions, clicks, …) must be 'available'."""
-        catalog = discover()
+        catalog = self._discover_catalog()
         cp = next(s for s in catalog.streams if s.tap_stream_id == "campaign_performance")
         mdata_map = metadata.to_map(cp.metadata)
         for field in ("impressions", "clicks", "spend", "ctr", "cpa"):

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -10,7 +10,6 @@ from singer import metadata as singer_metadata
 
 from .base import OutbrainBaseTest
 
-from tap_outbrain.discover import discover
 from tap_outbrain import get_date_ranges
 
 
@@ -94,7 +93,7 @@ class OutbrainBookmarkTest(OutbrainBaseTest):
 
     def test_campaign_performance_is_incremental_in_metadata(self):
         """Singer metadata confirms campaign_performance uses INCREMENTAL replication."""
-        catalog = discover()
+        catalog = self._discover_catalog()
         cp = next(s for s in catalog.streams if s.tap_stream_id == "campaign_performance")
         mdata_map = singer_metadata.to_map(cp.metadata)
         method = singer_metadata.get(mdata_map, (), "forced-replication-method")
@@ -102,7 +101,7 @@ class OutbrainBookmarkTest(OutbrainBaseTest):
 
     def test_campaign_is_full_table_in_metadata(self):
         """Singer metadata confirms campaign uses FULL_TABLE replication."""
-        catalog = discover()
+        catalog = self._discover_catalog()
         c = next(s for s in catalog.streams if s.tap_stream_id == "campaign")
         mdata_map = singer_metadata.to_map(c.metadata)
         method = singer_metadata.get(mdata_map, (), "forced-replication-method")
@@ -110,7 +109,7 @@ class OutbrainBookmarkTest(OutbrainBaseTest):
 
     def test_campaign_performance_valid_replication_key_is_from_date(self):
         """valid-replication-keys for campaign_performance is 'fromDate'."""
-        catalog = discover()
+        catalog = self._discover_catalog()
         cp = next(s for s in catalog.streams if s.tap_stream_id == "campaign_performance")
         mdata_map = singer_metadata.to_map(cp.metadata)
         rep_keys = singer_metadata.get(mdata_map, (), "valid-replication-keys")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,22 +1,20 @@
 """Catalog structure tests for tap-outbrain stream discovery.
 
-Calls tap_outbrain.discover.discover() directly — no HTTP calls required
-because discovery only reads local schema JSON files.  These tests are
-valid in both live and mock environments.
+Uses the shared test helper to run discovery with a mock client and
+without API access probes. These tests remain API-free and validate
+catalog and metadata structure only.
 """
 
 from singer import metadata
 
 from .base import OutbrainBaseTest
 
-from tap_outbrain.discover import discover
-
 
 class OutbrainDiscoveryTest(OutbrainBaseTest):
-    """Verify discover() returns the correct catalog without any API calls."""
+    """Verify discovery returns the correct catalog without API calls."""
 
     def _catalog(self):
-        return discover()
+        return self._discover_catalog()
 
     def test_discovery_returns_expected_streams(self):
         """All expected streams are present in the catalog."""

--- a/tests/unittests/test_catalog.py
+++ b/tests/unittests/test_catalog.py
@@ -124,11 +124,11 @@ class TestCatalogMetadata(unittest.TestCase):
 
     def test_streams_configuration(self):
         """Test that STREAMS configuration has correct parent attribute."""
-        # Verify Campaign class does not have parent attribute
-        self.assertFalse(hasattr(STREAMS['campaign'], 'parent'))
+        # Campaign is a root stream — parent is None (inherited from BaseStream)
+        self.assertIsNone(STREAMS['campaign'].parent)
 
         # Verify CampaignPerformance class has parent attribute set correctly
-        self.assertTrue(hasattr(STREAMS['campaign_performance'], 'parent'))
+        self.assertIsNotNone(STREAMS['campaign_performance'].parent)
         self.assertEqual(STREAMS['campaign_performance'].parent, 'campaign')
 
     @patch('builtins.open', new_callable=mock_open)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,11 +1,13 @@
 """Unit tests for tap_outbrain/discover.py"""
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from singer.catalog import Catalog, CatalogEntry
-from tap_outbrain.discover import discover
 
+from tap_outbrain.client import OutbrainForbiddenError
+from tap_outbrain.discover import (_apply_access_checks,
+                                   _prune_inaccessible_children, discover)
 
 _MOCK_CAMPAIGN_SCHEMA = {
     "type": "object",
@@ -48,37 +50,40 @@ def _build_mock_metadata(stream_name):
 
 class TestDiscover(unittest.TestCase):
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_returns_catalog_instance(self, mock_get_schemas):
-        """discover() returns a singer Catalog object."""
+    def test_returns_catalog_instance(self, mock_get_schemas, mock_access_checks):
+        """discover(client) returns a singer Catalog object."""
         mock_get_schemas.return_value = (
             _MOCK_SCHEMAS,
             {s: _build_mock_metadata(s) for s in _MOCK_SCHEMAS},
         )
-        result = discover()
+        result = discover(MagicMock())
         self.assertIsInstance(result, Catalog)
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_catalog_contains_all_streams(self, mock_get_schemas):
+    def test_catalog_contains_all_streams(self, mock_get_schemas, mock_access_checks):
         """Catalog contains one entry per schema returned by get_schemas."""
         mock_get_schemas.return_value = (
             _MOCK_SCHEMAS,
             {s: _build_mock_metadata(s) for s in _MOCK_SCHEMAS},
         )
-        result = discover()
+        result = discover(MagicMock())
         stream_names = [e.stream for e in result.streams]
         self.assertIn('campaign', stream_names)
         self.assertIn('campaign_performance', stream_names)
         self.assertEqual(len(result.streams), 2)
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_catalog_entry_has_correct_key_properties(self, mock_get_schemas):
+    def test_catalog_entry_has_correct_key_properties(self, mock_get_schemas, mock_access_checks):
         """Each CatalogEntry carries the correct key_properties from metadata."""
         mock_get_schemas.return_value = (
             _MOCK_SCHEMAS,
             {s: _build_mock_metadata(s) for s in _MOCK_SCHEMAS},
         )
-        result = discover()
+        result = discover(MagicMock())
         entry_by_name = {e.stream: e for e in result.streams}
 
         self.assertEqual(entry_by_name['campaign'].key_properties, ['id'])
@@ -87,25 +92,27 @@ class TestDiscover(unittest.TestCase):
             ['campaignId', 'fromDate'],
         )
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_tap_stream_id_matches_stream_name(self, mock_get_schemas):
+    def test_tap_stream_id_matches_stream_name(self, mock_get_schemas, mock_access_checks):
         """tap_stream_id should equal the stream name for every entry."""
         mock_get_schemas.return_value = (
             _MOCK_SCHEMAS,
             {s: _build_mock_metadata(s) for s in _MOCK_SCHEMAS},
         )
-        result = discover()
+        result = discover(MagicMock())
         for entry in result.streams:
             self.assertEqual(entry.tap_stream_id, entry.stream)
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_catalog_entry_schema_matches_input(self, mock_get_schemas):
+    def test_catalog_entry_schema_matches_input(self, mock_get_schemas, mock_access_checks):
         """The Schema on each CatalogEntry matches what get_schemas returned."""
         mock_get_schemas.return_value = (
             _MOCK_SCHEMAS,
             {s: _build_mock_metadata(s) for s in _MOCK_SCHEMAS},
         )
-        result = discover()
+        result = discover(MagicMock())
         entry_by_name = {e.stream: e for e in result.streams}
 
         # Schema.to_dict() should equal the original schema dict
@@ -117,13 +124,14 @@ class TestDiscover(unittest.TestCase):
             _MOCK_PERFORMANCE_SCHEMA,
         )
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_catalog_entry_metadata_preserved(self, mock_get_schemas):
+    def test_catalog_entry_metadata_preserved(self, mock_get_schemas, mock_access_checks):
         """Metadata list from get_schemas is stored on each CatalogEntry."""
         field_metadata = {s: _build_mock_metadata(s) for s in _MOCK_SCHEMAS}
         mock_get_schemas.return_value = (_MOCK_SCHEMAS, field_metadata)
 
-        result = discover()
+        result = discover(MagicMock())
         entry_by_name = {e.stream: e for e in result.streams}
 
         self.assertEqual(
@@ -131,28 +139,30 @@ class TestDiscover(unittest.TestCase):
             field_metadata['campaign_performance'],
         )
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_discover_with_single_stream(self, mock_get_schemas):
-        """discover() handles a catalog with only one stream."""
+    def test_discover_with_single_stream(self, mock_get_schemas, mock_access_checks):
+        """discover(client) handles a catalog with only one stream."""
         single_schema = {'campaign': _MOCK_CAMPAIGN_SCHEMA}
         mock_get_schemas.return_value = (
             single_schema,
             {'campaign': _build_mock_metadata('campaign')},
         )
-        result = discover()
+        result = discover(MagicMock())
         self.assertEqual(len(result.streams), 1)
         self.assertEqual(result.streams[0].stream, 'campaign')
 
     @patch('tap_outbrain.discover.get_schemas')
     def test_discover_propagates_get_schemas_exception(self, mock_get_schemas):
-        """If get_schemas raises, discover() propagates the exception."""
+        """If get_schemas raises, discover(client) propagates the exception."""
         mock_get_schemas.side_effect = RuntimeError("Schema load failed")
         with self.assertRaises(RuntimeError):
-            discover()
+            discover(MagicMock())
 
+    @patch('tap_outbrain.discover._apply_access_checks')
     @patch('tap_outbrain.discover.get_schemas')
-    def test_discover_logs_and_reraises_schema_error(self, mock_get_schemas):
-        """When Schema.from_dict fails, discover() re-raises the exception."""
+    def test_discover_logs_and_reraises_schema_error(self, mock_get_schemas, mock_access_checks):
+        """When Schema.from_dict fails, discover(client) re-raises the exception."""
         # Provide a schema that is valid dict but will fail Schema.from_dict indirectly
         bad_schemas = {'campaign': None}  # None will cause AttributeError in Schema.from_dict
         mock_get_schemas.return_value = (
@@ -160,4 +170,215 @@ class TestDiscover(unittest.TestCase):
             {'campaign': _build_mock_metadata('campaign')},
         )
         with self.assertRaises(Exception):
-            discover()
+            discover(MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by the access-check test classes
+# ---------------------------------------------------------------------------
+
+def _make_stream_cls(accessible=True, parent=None):
+    """
+    Return a mock stream *class* (not instance) whose instantiation returns
+    an object with ``check_access()`` set to *accessible* and whose
+    ``parent`` class attribute equals *parent*.
+    """
+    cls = MagicMock()
+    cls.parent = parent
+    instance = MagicMock()
+    instance.check_access.return_value = accessible
+    cls.return_value = instance
+    return cls
+
+
+def _make_client():
+    from tap_outbrain.client import OutbrainClient
+    return OutbrainClient(config={"account_id": "acct1", "access_token": "tok"})
+
+
+# ---------------------------------------------------------------------------
+# _apply_access_checks
+# ---------------------------------------------------------------------------
+
+class TestApplyAccessChecks(unittest.TestCase):
+
+    def _schemas_and_meta(self):
+        schemas = dict(_MOCK_SCHEMAS)
+        meta = {s: _build_mock_metadata(s) for s in schemas}
+        return schemas, meta
+
+    @patch("tap_outbrain.discover.STREAMS")
+    def test_all_accessible_leaves_catalog_intact(self, mock_streams):
+        """When all streams are accessible, schemas and metadata are unchanged."""
+        mock_streams.items.return_value = [
+            ("campaign", _make_stream_cls(accessible=True, parent=None)),
+            ("campaign_performance", _make_stream_cls(accessible=True, parent="campaign")),
+        ]
+        schemas, meta = self._schemas_and_meta()
+        _apply_access_checks(_make_client(), schemas, meta)
+
+        self.assertIn("campaign", schemas)
+        self.assertIn("campaign_performance", schemas)
+
+    @patch("tap_outbrain.discover.STREAMS")
+    def test_inaccessible_parent_removed(self, mock_streams):
+        """An inaccessible parent stream is removed from schemas and metadata."""
+        mock_streams.items.return_value = [
+            ("campaign", _make_stream_cls(accessible=False, parent=None)),
+            ("campaign_performance", _make_stream_cls(accessible=True, parent="campaign")),
+        ]
+        schemas, meta = self._schemas_and_meta()
+        # _prune_inaccessible_children also checks STREAMS so patch it globally
+        with patch("tap_outbrain.discover.STREAMS") as mock_streams2:
+            mock_streams2.items.return_value = [
+                ("campaign", _make_stream_cls(accessible=False, parent=None)),
+                ("campaign_performance", _make_stream_cls(accessible=True, parent="campaign")),
+            ]
+            # Both apply_access_checks' own loop and _prune need the patch
+            # Re-run with a single consistent patch at module level
+            pass
+
+        # Simpler: patch once via STREAMS at module level
+        streams_dict = {
+            "campaign": _make_stream_cls(accessible=False, parent=None),
+            "campaign_performance": _make_stream_cls(accessible=True, parent="campaign"),
+        }
+        with patch.dict("tap_outbrain.discover.STREAMS", streams_dict, clear=True):
+            schemas, meta = self._schemas_and_meta()
+            with self.assertRaises(OutbrainForbiddenError):
+                # campaign removed → only campaign_performance remains,
+                # then _prune removes it too → no schemas → raises
+                _apply_access_checks(_make_client(), schemas, meta)
+
+    @patch.dict(
+        "tap_outbrain.discover.STREAMS",
+        {
+            "campaign": _make_stream_cls(accessible=False, parent=None),
+            "campaign_performance": _make_stream_cls(accessible=True, parent="campaign"),
+        },
+        clear=True,
+    )
+    def test_all_inaccessible_raises_forbidden_error(self):
+        """OutbrainForbiddenError is raised when no streams remain after pruning."""
+        schemas, meta = {**_MOCK_SCHEMAS}, {s: _build_mock_metadata(s) for s in _MOCK_SCHEMAS}
+        with self.assertRaises(OutbrainForbiddenError) as ctx:
+            _apply_access_checks(_make_client(), schemas, meta)
+        self.assertIn("403", str(ctx.exception))
+        self.assertIn("read", str(ctx.exception))
+
+    def test_inaccessible_warning_logged(self):
+        """A warning is logged for each excluded stream when some remain."""
+        accessible_campaign = _make_stream_cls(accessible=True, parent=None)
+        streams_dict = {
+            "campaign": accessible_campaign,
+            "campaign_performance": _make_stream_cls(accessible=True, parent="campaign"),
+        }
+        with patch.dict("tap_outbrain.discover.STREAMS", streams_dict, clear=True):
+            schemas, meta = self._schemas_and_meta()
+            # All accessible → no warning, no raise
+            with patch("tap_outbrain.discover.LOGGER") as mock_logger:
+                _apply_access_checks(_make_client(), schemas, meta)
+                mock_logger.warning.assert_not_called()
+
+    def test_partial_access_excludes_forbidden_streams(self):
+        """When one stream is inaccessible and a sibling remains, no error is raised."""
+        # We need two independent parent streams. Temporarily extend STREAMS.
+        extra_cls = _make_stream_cls(accessible=True, parent=None)
+        extra_cls.name = "extra_stream"
+        forbidden_cls = _make_stream_cls(accessible=False, parent=None)
+        forbidden_cls.name = "campaign"
+
+        extra_schema = {"type": "object", "properties": {}}
+        streams_dict = {
+            "campaign": forbidden_cls,
+            "extra_stream": extra_cls,
+        }
+        schemas = {"campaign": _MOCK_CAMPAIGN_SCHEMA, "extra_stream": extra_schema}
+        meta = {
+            "campaign": _build_mock_metadata("campaign"),
+            "extra_stream": _build_mock_metadata("campaign"),
+        }
+        with patch.dict("tap_outbrain.discover.STREAMS", streams_dict, clear=True):
+            _apply_access_checks(_make_client(), schemas, meta)
+
+        self.assertNotIn("campaign", schemas)
+        self.assertIn("extra_stream", schemas)
+
+
+# ---------------------------------------------------------------------------
+# _prune_inaccessible_children
+# ---------------------------------------------------------------------------
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+
+    def test_child_removed_when_parent_absent(self):
+        """
+        A child stream is pruned from schemas when its parent is not present.
+        """
+        parent_cls = _make_stream_cls(parent=None)
+        child_cls = _make_stream_cls(parent="campaign")
+
+        with patch.dict(
+            "tap_outbrain.discover.STREAMS",
+            {"campaign": parent_cls, "campaign_performance": child_cls},
+            clear=True,
+        ):
+            schemas = {"campaign_performance": _MOCK_PERFORMANCE_SCHEMA}
+            meta = {"campaign_performance": _build_mock_metadata("campaign_performance")}
+            _prune_inaccessible_children(schemas, meta)
+
+        self.assertNotIn("campaign_performance", schemas)
+        self.assertNotIn("campaign_performance", meta)
+
+    def test_child_retained_when_parent_present(self):
+        """
+        A child stream is kept when its parent stream is still in schemas.
+        """
+        parent_cls = _make_stream_cls(parent=None)
+        child_cls = _make_stream_cls(parent="campaign")
+
+        with patch.dict(
+            "tap_outbrain.discover.STREAMS",
+            {"campaign": parent_cls, "campaign_performance": child_cls},
+            clear=True,
+        ):
+            schemas = dict(_MOCK_SCHEMAS)
+            meta = {s: _build_mock_metadata(s) for s in schemas}
+            _prune_inaccessible_children(schemas, meta)
+
+        self.assertIn("campaign_performance", schemas)
+
+    def test_streams_without_parent_unaffected(self):
+        """
+        Streams with no parent attribute are never removed by pruning.
+        """
+        parent_cls = _make_stream_cls(parent=None)
+
+        with patch.dict(
+            "tap_outbrain.discover.STREAMS",
+            {"campaign": parent_cls},
+            clear=True,
+        ):
+            schemas = {"campaign": _MOCK_CAMPAIGN_SCHEMA}
+            meta = {"campaign": _build_mock_metadata("campaign")}
+            _prune_inaccessible_children(schemas, meta)
+
+        self.assertIn("campaign", schemas)
+
+    def test_warning_logged_on_child_pruning(self):
+        """A warning is emitted when a child stream is pruned."""
+        parent_cls = _make_stream_cls(parent=None)
+        child_cls = _make_stream_cls(parent="campaign")
+
+        with patch.dict(
+            "tap_outbrain.discover.STREAMS",
+            {"campaign": parent_cls, "campaign_performance": child_cls},
+            clear=True,
+        ):
+            schemas = {"campaign_performance": _MOCK_PERFORMANCE_SCHEMA}
+            meta = {"campaign_performance": _build_mock_metadata("campaign_performance")}
+            with patch("tap_outbrain.discover.LOGGER") as mock_logger:
+                _prune_inaccessible_children(schemas, meta)
+                mock_logger.warning.assert_called_once()
+                warn_msg = mock_logger.warning.call_args[0][0]
+                self.assertIn("excluded", warn_msg)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -228,27 +228,10 @@ class TestApplyAccessChecks(unittest.TestCase):
             ("campaign_performance", _make_stream_cls(accessible=True, parent="campaign")),
         ]
         schemas, meta = self._schemas_and_meta()
-        # _prune_inaccessible_children also checks STREAMS so patch it globally
-        with patch("tap_outbrain.discover.STREAMS") as mock_streams2:
-            mock_streams2.items.return_value = [
-                ("campaign", _make_stream_cls(accessible=False, parent=None)),
-                ("campaign_performance", _make_stream_cls(accessible=True, parent="campaign")),
-            ]
-            # Both apply_access_checks' own loop and _prune need the patch
-            # Re-run with a single consistent patch at module level
-            pass
-
-        # Simpler: patch once via STREAMS at module level
-        streams_dict = {
-            "campaign": _make_stream_cls(accessible=False, parent=None),
-            "campaign_performance": _make_stream_cls(accessible=True, parent="campaign"),
-        }
-        with patch.dict("tap_outbrain.discover.STREAMS", streams_dict, clear=True):
-            schemas, meta = self._schemas_and_meta()
-            with self.assertRaises(OutbrainForbiddenError):
-                # campaign removed → only campaign_performance remains,
-                # then _prune removes it too → no schemas → raises
-                _apply_access_checks(_make_client(), schemas, meta)
+        with self.assertRaises(OutbrainForbiddenError):
+            # campaign removed → only campaign_performance remains,
+            # then _prune removes it too → no schemas → raises
+            _apply_access_checks(_make_client(), schemas, meta)
 
     @patch.dict(
         "tap_outbrain.discover.STREAMS",
@@ -296,7 +279,7 @@ class TestApplyAccessChecks(unittest.TestCase):
         schemas = {"campaign": _MOCK_CAMPAIGN_SCHEMA, "extra_stream": extra_schema}
         meta = {
             "campaign": _build_mock_metadata("campaign"),
-            "extra_stream": _build_mock_metadata("campaign"),
+            "extra_stream": [],
         }
         with patch.dict("tap_outbrain.discover.STREAMS", streams_dict, clear=True):
             _apply_access_checks(_make_client(), schemas, meta)

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -327,14 +327,15 @@ class TestDoDiscover(unittest.TestCase):
     @patch('sys.stdout')
     @patch('tap_outbrain.discover')
     def test_do_discover_dumps_catalog(self, mock_discover, mock_stdout):
-        """do_discover calls discover() and writes JSON to stdout."""
+        """do_discover calls discover(client) and writes JSON to stdout."""
         mock_catalog = MagicMock()
         mock_catalog.to_dict.return_value = {'streams': []}
         mock_discover.return_value = mock_catalog
+        mock_client = MagicMock()
 
-        do_discover()
+        do_discover(mock_client)
 
-        mock_discover.assert_called_once()
+        mock_discover.assert_called_once_with(mock_client)
         mock_catalog.to_dict.assert_called_once()
 
 


### PR DESCRIPTION
# Description of change
- Handle discovery time check of streams by passing client (optional) to discovery
- Excluded streams which return 403 error code when running discovery due to permission error
- Added unit tests to validate the workflow.

# Manual QA steps
 - [x] Discovery running
 - [x] Unittest running
 - [x] Integration tests running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
